### PR TITLE
Add analytics

### DIFF
--- a/src/_includes/analytics.html
+++ b/src/_includes/analytics.html
@@ -1,0 +1,10 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-26406144-25', 'auto');
+  ga('send', 'pageview');
+
+</script>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -38,4 +38,5 @@
   {% for js in page.js %}
   <script {% if js.defer %}defer{% endif %} src="{{ js.url }}"></script>
   {% endfor %}
+  {% include analytics.html %}
 </head>


### PR DESCRIPTION
We might want to change to share a tracking ID with www, but for now, this is a simple solution that should work.

@tbeck & @filiph, same questions apply here as to https://github.com/dart-lang/site-www/pull/1.

Also, I noticed that this code (which is an exact copy of what the Analytics site tells me to use) uses https:// instead of //. For consistency's sake, I might change the www code to match.