### PR TITLE
chore: code-example and code-tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tmp
 
 # Misc
 trash
+.idea
 
 firebase-debug.log
 node_modules
@@ -25,3 +26,5 @@ node_modules
 # /src/angular/_jade/ts
 # /src/angular/guide
 # /src/angular/tutorial
+
+/src/styles/angular/angular.css

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,6 +44,7 @@ gutil.log(`Using angular.io repo at ${angulario}`)
 //
 
 // gulp.task('sass', cb => Q.all(_sass('src'), _sass('public')));
+gulp.task('sass', cb => _sass('src/styles'));
 gulp.task('clean-src', cb => execp(`git clean -xdf src`));
 
 gulp.task('site-refresh', ['_clean', 'get-ngio-files']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,6 @@ gutil.log(`Using angular.io repo at ${angulario}`)
 //
 
 // gulp.task('sass', cb => Q.all(_sass('src'), _sass('public')));
-gulp.task('sass-after-clean', ['clean-src'], cb => Q.all(_sass('src'), _sass('public')));
 gulp.task('clean-src', cb => execp(`git clean -xdf src`));
 
 gulp.task('site-refresh', ['_clean', 'get-ngio-files']);

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -51,6 +51,9 @@
 
   <!-- Extra for angular -->
   {% if page.angular %}
+  <!-- Angular.io styles for directives -->
+  <link rel="stylesheet" href="/styles/angular/angular.css">
+
   <!-- VENDORS -->
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0/angular-material.min.css"/>
   <!-- Probably don't need these under webdev

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -52,6 +52,7 @@
   <!-- Extra for angular -->
   {% if page.angular %}
   <!-- VENDORS -->
+  <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0/angular-material.min.css"/>
   <!-- Probably don't need these under webdev
   <script src="/resources/js/vendor/prettify.js"></script>
   <script src="/resources/js/vendor/lang-basic.js"></script>

--- a/src/styles/angular/_button.scss
+++ b/src/styles/angular/_button.scss
@@ -1,0 +1,78 @@
+/*
+* Button Styles
+*
+*/
+
+.button,
+a.button.md-button {
+  display: inline-block;
+  line-height: $unit * 4;
+  padding: 0px ($unit * 2);
+  font-size: 14px;
+  font-weight: 400;
+  border-radius: 3px;
+  text-decoration: none;
+  text-transform: uppercase;
+  overflow: hidden;
+  border: none;
+
+  // SIZES
+  &.button-small {
+    font-size: 12px;
+    line-height: $unit * 3;
+    padding: 0px ($unit * 1);
+  }
+
+  &.button-large {
+    font-size: 15px;
+    line-height: $unit * 6;
+    padding: 0px ($unit * 3);
+  }
+
+  &.button-x-large {
+    font-size: 16px;
+    line-height: $unit * 7;
+    padding: 0px ($unit * 3);
+  }
+
+
+  // COLORS
+
+  &.button-secondary {
+    background: $fog;
+    color: rgba($white, .87);
+  }
+
+  &.button-plain {
+    background: $white;
+    color: rgba($steel, .87);
+  }
+
+  &.button-subtle {
+    background: $mist;
+    color: darken($cloud, 10%);
+  }
+
+  &.button-navy {
+    background: $ocean;
+    color: rgba($white, .87);
+  }
+
+  &.button-banner {
+    background: $metal;
+    color: rgba($white, .87);
+  }
+
+  //&.button-shield,
+  //&.button-shield.md-button {
+  //  background-color: $blue-600;
+  //  background: $blue-600 url('/resources/images/logos/inverse/shield/22.png') 24px 13px no-repeat;
+  //  color: rgba($white, .87);
+  //  padding-left: 54px;
+  //
+  //  @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2) {
+  //    background: $blue-600 url('/resources/images/logos/inverse/shield/22@2x.png') 24px 13px no-repeat;
+  //    background-size: 22px 22px;
+  //  }
+  //}
+}

--- a/src/styles/angular/_code-box.scss
+++ b/src/styles/angular/_code-box.scss
@@ -1,0 +1,78 @@
+/*
+* Code Box Module
+*
+* Code examples with multiple sections (tabs)
+*
+*/
+
+
+/*
+* Variables
+*/
+
+$codebox-anti-pattern-color: $red-700;
+$codebox-primary-color: $blue-700;
+$codebox-selected: $white;
+
+
+/*
+* Class
+*/
+
+.code-box,
+.code-example {
+  background: $white;
+  border: 2px solid $codebox-primary-color;
+  border-radius: 4px;
+  box-shadow: 0 2px 2px rgba($black, 0.24), 0 0 2px rgba($black, 0.12);
+  margin-bottom: $unit * 3;
+
+  &.is-anti-pattern {
+    border: 2px solid $codebox-anti-pattern-color;
+
+    header {
+      background: $codebox-anti-pattern-color;
+    }
+  }
+
+  header {
+    background: $codebox-primary-color;
+    color: $white;
+    padding: $unit $unit 0 $unit;
+  }
+
+  h4 {
+    color: $white;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: $unit * 3;
+    margin: 0;
+    outline: none;
+    opacity: 1;
+    padding: 0 0 $unit $unit;
+    text-transform: none;
+  }
+
+  nav button {
+    background: $blue-600;
+    border-radius: 2px 2px 0 0;
+    color: $white;
+    font-size: 13px;
+    height: $unit * 4;
+    line-height: $unit * 4;
+    margin-right: $unit;
+    outline: none;
+    padding: 0 ($unit * 3);
+    text-transform: none;
+
+    &.is-selected,
+    &.selected {
+      background: $white;
+      color: $blue-grey-600;
+    }
+  }
+
+  .prettyprint {
+    background: $codebox-selected;
+  }
+}

--- a/src/styles/angular/_code.scss
+++ b/src/styles/angular/_code.scss
@@ -1,0 +1,232 @@
+/*
+* Code Syntax Highlighting & Formatting
+*
+*/
+
+
+/*
+* Variables
+*/
+
+$prettyprint-background: $white;
+$prettyprint-color: $blue-grey-700;
+
+
+/*
+* Copy Code Button
+*/
+
+.copy-container-template {
+  position: relative;
+
+  &:hover .copy-button .md-button {
+    opacity: 1;
+  }
+
+  .copy-button {
+    &.is-copied .md-button {
+      background: $blue-grey-50;
+      box-shadow: none;
+      color: $cyan-500;
+      min-width: 98px;
+    }
+
+    .md-button {
+      background: $cyan-500;
+      border-radius: 2px;
+      box-shadow: 0 2px 2px rgba($black, 0.24), 0 0 2px rgba($black, 0.12);
+      color: $white;
+      font-size: 12px;
+      height: $unit * 4;
+      line-height: $unit * 4;
+      min-height: $unit * 4;
+      min-width: 98px;
+      margin: 0;
+      opacity: 0;
+      right: $unit * 2;
+      padding: 0 ($unit * 2);
+      position: absolute;
+      top: $unit * 2;
+      z-index: 1;
+      transition: all .2s;
+    }
+  }
+}
+
+
+/*
+* Pretty Print Styles
+*/
+
+.prettyprint {
+  background: $prettyprint-background;
+  white-space: pre-wrap;
+  color: $prettyprint-color;
+  font-family: $mono-font;
+  font-size: 14px;
+  line-height: 24px;
+  margin: 0;
+  overflow: auto;
+  position: relative;
+  padding: 0px;
+  padding: ($unit * 2) ($unit * 4);
+  width: auto;
+
+  &.linenums,
+  &[class^="linenums:"],
+  &[class*=" linenums:"]  {
+    padding: 0px;
+  }
+
+  &.is-showcase {
+    border: 4px solid $blue-600;
+  }
+
+  code {
+    background: none;
+    font-size: 13px;
+    padding: 0px;
+  }
+
+  ol {
+    background: rgba($blue-grey-50, .24);
+    color: $blue-grey-200;
+    padding: 0 0 0 ($unit * 5);
+    margin: 0px;
+    overflow: auto;
+    font-size: 11px;
+
+    li {
+      background: $white;
+      margin: 0;
+      line-height: $unit * 3;
+      list-style-type: decimal;
+      padding: 0 0 0 ($unit * 2);
+
+      &:first-child {
+        padding-top: $unit * 3;
+      }
+      &:last-child {
+        margin-bottom: 0;
+        padding-bottom: $unit * 3;
+      }
+
+      code {
+        background: none;
+        color: $blue-grey-700;
+        font-size: 13px;
+      }
+    }
+  }
+
+
+  /*
+  * Screen Colors
+  *
+  */
+
+  .pnk,
+  .blk {
+    border-radius: 4px;
+    padding: 2px 4px;
+  }
+  .pnk {
+    background: $blue-grey-50;
+    color: $blue-grey-900;
+  }
+  .blk {
+    background: $blue-grey-900;
+  }
+  .otl {
+    outline: 1px solid rgba($blue-grey-700, .56);
+  }
+  .kwd {
+    color: $pink-600;
+  }
+  .typ,
+  .tag {
+    color: $pink-600;
+  }
+  .str,
+  .atv {
+    color: $teal-700;
+  }
+  .atn {
+    color: $teal-700;
+  }
+  .com {
+    color: $teal-700;
+  }
+  .lit {
+    color: $teal-700;
+  }
+  .pun {
+    color: $blue-grey-700;
+  }
+  .pln {
+    color: $blue-grey-700;
+  }
+  .dec {
+    color: $teal-700;
+  }
+
+
+  /*
+  * Print Colors
+  *
+  */
+
+  @media print {
+    border: none;
+    box-shadow: none;
+
+    ol {
+      background: $white;
+    }
+
+    .kwd {
+      color: $pink-600;
+    }
+    .typ,
+    .tag {
+      color: $pink-600;
+    }
+    .str,
+    .atv {
+      color: $teal-700;
+    }
+    .atn {
+      color: $teal-700;
+    }
+    .com {
+      color: $teal-700;
+    }
+    .lit {
+      color: $teal-700;
+    }
+    .pun {
+      color: $blue-grey-700;
+    }
+    .pln {
+      color: $blue-grey-700;
+    }
+    .dec {
+      color: $teal-700;
+    }
+  }
+}
+
+
+/*
+* Embedded Code
+*
+* Style for embedded code examples
+*/
+
+.cp_embed_iframe {
+  overflow: hidden;
+
+  @include respond-to('mobile') {
+    width: 240px !important;
+  }
+}

--- a/src/styles/angular/_options.scss
+++ b/src/styles/angular/_options.scss
@@ -1,0 +1,37 @@
+/*
+* Typography
+*
+* Only the fonts listed below should be used throughout the site.
+*/
+
+$brand-font: 'Roboto', "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+$mono-font: Monaco, "Lucida Console", monospace;
+
+
+/*
+* Metrics
+*
+* Metrics based on material design 8pt unit
+*/
+
+$unit: 8px;
+$phone-breakpoint: 480px;
+$tablet-breakpoint: 800px;
+
+
+/*
+* Layer Stacking
+*
+* The approved range that can be used for layering (z-indexes)
+*/
+
+$layer-1: 1;
+$layer-2: 2;
+$layer-3: 3;
+$layer-4: 4;
+$layer-5: 5;
+$layer-6: 6;
+$layer-7: 7;
+$layer-8: 8;
+$layer-9: 9;
+$layer-10: 10;

--- a/src/styles/angular/angular.scss
+++ b/src/styles/angular/angular.scss
@@ -1,0 +1,12 @@
+/* -----------------------------------------
+  Angular
+  ----------------------------------------- */
+
+@import 'base/_colors';
+@import 'base/_reset';
+@import 'base/_mixin';
+
+@import '_options';
+@import '_code';
+@import '_code-box';
+@import '_button';

--- a/src/styles/angular/base/_colors.scss
+++ b/src/styles/angular/base/_colors.scss
@@ -1,0 +1,279 @@
+/*
+* Material Design Colors
+*
+* Colors based off the material design palette
+* https://material.google.com/style/color.html#color-color-palette
+*
+*/
+
+
+/*
+* Black & White
+*
+*/
+
+$white: #FFFFFF;
+$black: #000000;
+
+
+/*
+* Amber
+*
+*/
+
+$amber-50: #FFF8E1;
+$amber-100: #FFECB3;
+$amber-200: #FFE082;
+$amber-300: #FFD54F;
+$amber-400: #FFCA28;
+$amber-500: #FFC107;
+$amber-600: #FFB300;
+$amber-700: #FFA000;
+$amber-800: #FF8F00;
+$amber-900: #FF6F00;
+$amber-A100: #FFE57F;
+$amber-A200: #FFD740;
+$amber-A400: #FFC400;
+$amber-A700: #FFAB00;
+
+
+/*
+* Blue Grey
+*
+*/
+
+$blue-grey-50: #ECEFF1;
+$blue-grey-100: #CFD8DC;
+$blue-grey-200: #B0BEC5;
+$blue-grey-300: #90A4AE;
+$blue-grey-400: #78909C;
+$blue-grey-500: #607D8B;
+$blue-grey-600: #546E7A;
+$blue-grey-700: #455A64;
+$blue-grey-800: #37474F;
+$blue-grey-900: #263238;
+
+
+/*
+* Blue
+*
+*/
+
+$blue-50: #E3F2FD;
+$blue-100: #BBDEFB;
+$blue-200: #90CAF9;
+$blue-300: #64B5F6;
+$blue-400: #42A5F5;
+$blue-500: #2196F3;
+$blue-600: #1E88E5;
+$blue-700: #1976D2;
+$blue-800: #1565C0;
+$blue-900: #0D47A1;
+$blue-A100: #82B1FF;
+$blue-A200: #448AFF;
+$blue-A400: #2979FF;
+$blue-A700: #2962FF;
+
+
+/*
+* Cyan
+*
+*/
+
+$cyan-50: #E0F7FA;
+$cyan-100: #B2EBF2;
+$cyan-200: #80DEEA;
+$cyan-300: #4DD0E1;
+$cyan-400: #26C6DA;
+$cyan-500: #00BCD4;
+$cyan-600: #00ACC1;
+$cyan-700: #0097A7;
+$cyan-800: #00838F;
+$cyan-900: #006064;
+$cyan-A100: #84FFFF;
+$cyan-A200: #18FFFF;
+$cyan-A400: #00E5FF;
+$cyan-A700: #00B8D4;
+
+
+/*
+* Green
+*
+*/
+
+$green-50: #E8F5E9;
+$green-100: #C8E6C9;
+$green-200: #A5D6A7;
+$green-300: #81C784;
+$green-400: #66BB6A;
+$green-500: #4CAF50;
+$green-600: #43A047;
+$green-700: #388E3C;
+$green-800: #2E7D32;
+$green-900: #1B5E20;
+$green-A100: #B9F6CA;
+$green-A200: #69F0AE;
+$green-A400: #00E676;
+$green-A700: #00C853;
+
+
+/*
+* Light Green
+*
+*/
+
+$light-green-50: #F1F8E9;
+$light-green-100: #DCEDC8;
+$light-green-200: #C5E1A5;
+$light-green-300: #AED581;
+$light-green-400: #9CCC65;
+$light-green-500: #8BC34A;
+$light-green-600: #7CB342;
+$light-green-700: #689F38;
+$light-green-800: #558B2F;
+$light-green-900: #33691E;
+$light-green-A100: #CCFF90;
+$light-green-A200: #B2FF59;
+$light-green-A400: #76FF03;
+$light-green-A700: #64DD17;
+
+
+/*
+* Red
+*
+*/
+
+$red-50: #FFEBEE;
+$red-100: #FFCDD2;
+$red-200: #EF9A9A;
+$red-300: #E57373;
+$red-400: #EF5350;
+$red-500: #F44336;
+$red-600: #E53935;
+$red-700: #D32F2F;
+$red-800: #C62828;
+$red-900: #B71C1C;
+$red-A100: #FF8A80;
+$red-A200: #FF5252;
+$red-A400: #FF1744;
+$red-A700: #D50000;
+
+
+/*
+* Pink
+*
+*/
+
+$pink-50: #FCE4EC;
+$pink-100: #F8BBD0;
+$pink-200: #F48FB1;
+$pink-300: #F06292;
+$pink-400: #EC407A;
+$pink-500: #E91E63;
+$pink-600: #D81B60;
+$pink-700: #C2185B;
+$pink-800: #AD1457;
+$pink-900: #880E4F;
+$pink-A100: #FF80AB;
+$pink-A200: #FF4081;
+$pink-A400: #F50057;
+$pink-A700: #C51162;
+
+
+/*
+* Purple
+*
+*/
+
+$purple-50: #F3E5F5;
+$purple-100: #E1BEE7;
+$purple-200: #CE93D8;
+$purple-300: #BA68C8;
+$purple-400: #AB47BC;
+$purple-500: #9C27B0;
+$purple-600: #8E24AA;
+$purple-700: #7B1FA2;
+$purple-800: #6A1B9A;
+$purple-900: #4A148C;
+$purple-A100: #EA80FC;
+$purple-A200: #E040FB;
+$purple-A400: #D500F9;
+$purple-A700: #AA00FF;
+
+
+/*
+* Teal
+*
+*/
+
+$teal-50: #E0F2F1;
+$teal-100: #B2DFDB;
+$teal-200: #80CBC4;
+$teal-300: #4DB6AC;
+$teal-400: #26A69A;
+$teal-500: #009688;
+$teal-600: #00897B;
+$teal-700: #00796B;
+$teal-800: #00695C;
+$teal-900: #004D40;
+$teal-A100: #A7FFEB;
+$teal-A200: #64FFDA;
+$teal-A400: #1DE9B6;
+$teal-A700: #00BFA5;
+
+
+/*
+* Orginial Colors
+*
+* Colors are ordered from light to dark (top to bottom).
+* Do not use hex codes directly in other Sass files. The
+* following colors are the only approved colors for this site.
+*/
+
+// GREEN COLORS
+$cactus: #8BC34A;
+
+// YELLOW
+$sunshine: #FFF59D;
+$olive: #647f11;
+
+// ORANGE
+$sand: #FFF8E1;
+$citrus: #FF8F00;
+
+// RED COLORS
+$peach: #ffebee;
+$squid: #EF3872;
+$cardinal: #E23237;
+$ruby: #B52E31;
+$pink: #D43669;
+
+// BLUE COLORS
+$light: #E3F2FD;
+$sky: #0085D3;
+$regal: #0273D4;
+$blueberry: #0262C2;
+$ocean: #0143A3;
+
+//PURPLE
+$grape: #9575CD;
+
+// DARK GRAY COLORS
+$coal: #000000;
+$steel: #253238;
+$silver: #36474F;
+$platinum: #445A64;
+$metal: #536E7A;
+$tin: #8FA4AE;
+$darkgrey: #5C707A;
+$bismark: #7a8b94;
+$grey: #B0BEC5;
+
+// LIGHT GRAY COLORS
+$cloud: #AFBEC5;
+$fog: #CFD8DC;
+$mist: #ECEFF1;
+$snow: #FFFFFF;
+$heather: #546E7A;
+$lightgrey: #F5F6F7;
+$storm: #E0E0E0;

--- a/src/styles/angular/base/_mixin.scss
+++ b/src/styles/angular/base/_mixin.scss
@@ -1,0 +1,24 @@
+$phone-breakpoint: 480px !default;
+$tablet-breakpoint: 800px !default;
+
+
+@mixin respond-to($media) {
+  @if $media == mobile {
+    @media handheld and (max-width: $phone-breakpoint),
+    screen and (max-device-width: $phone-breakpoint),
+    screen and (max-width: $tablet-breakpoint) {
+      @content;
+    }
+  }
+  @else if $media == phones {
+    @media handheld and (max-width: $phone-breakpoint),
+    screen and (max-device-width: $phone-breakpoint) {
+      @content;
+    }
+  }
+  @else if $media == tablets {
+    @media screen and (max-width: $tablet-breakpoint) {
+      @content;
+    }
+  }
+}

--- a/src/styles/angular/base/_reset.scss
+++ b/src/styles/angular/base/_reset.scss
@@ -1,0 +1,427 @@
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability when focused and also mouse hovered in all browsers.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+ *    (include `-moz` to future-proof).
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box; /* 2 */
+  box-sizing: content-box;
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}


### PR DESCRIPTION
There might be more directives missing styles, however, these are the most visually obvious.

As an aside, the styles could be altered by switching the colours to match Dart, as opposed to angular.io

![screen shot 2016-11-14 at 1 08 59 pm](https://cloud.githubusercontent.com/assets/1329167/20276739/8ffdbaa0-aa6b-11e6-96e9-87ca37c7f441.png)
