### PR TITLE
[ng] docs(template-syntax): fix filename for code excerpt

### DIFF
--- a/src/angular/_jade/ts/_cache/guide/template-syntax.jade
+++ b/src/angular/_jade/ts/_cache/guide/template-syntax.jade
@@ -788,10 +788,8 @@ block style-property-name-dart-diff
   The best it can do is raise an event reporting the user's delete request.
 
   Here are the pertinent excerpts from that `HeroDetailComponent`:
-+makeExample('template-syntax/ts/app/hero-detail.component.ts',
-'template-1', 'HeroDetailComponent.ts (template)')(format=".")
-+makeExample('template-syntax/ts/app/hero-detail.component.ts',
-'deleteRequest', 'HeroDetailComponent.ts (delete logic)')(format=".")
++makeExcerpt('app/hero-detail.component.ts (template)', 'template-1')
++makeExcerpt('app/hero-detail.component.ts', 'deleteRequest')
 
 :marked
   The component defines a `deleteRequest` property that returns an `EventEmitter`.
@@ -800,8 +798,8 @@ block style-property-name-dart-diff
 
   Now imagine a hosting parent component that binds to the `HeroDetailComponent`'s `deleteRequest` event.
 
-+makeExample('template-syntax/ts/app/app.component.html',
-'event-binding-to-component')(format=".")
++makeExcerpt('app/app.component.html', 'event-binding-to-component', '')
+
 :marked
   When the `deleteRequest` event fires, Angular calls the parent component's `deleteHero` method,
   passing the *hero-to-delete* (emitted by `HeroDetail`) in the `$event` variable.
@@ -904,8 +902,7 @@ a#ngModel
   When developing data entry forms, we often want to both display a data property and update that property when the user makes changes.
 
   Two-way data binding with the `NgModel` directive makes that easy. Here's an example:
-+makeExample('template-syntax/ts/app/app.component.html', 'NgModel-1')(format=".")
-
++makeExcerpt('app/app.component.html', 'NgModel-1', '')
 
 +ifDocsFor('ts|js')
   .callout.is-important
@@ -917,7 +914,7 @@ a#ngModel
       [Forms](../guide/forms.html#ngModel) chapter.
   :marked
     Here's how to import the `FormsModule` to make `[(ngModel)]` available.
-  +makeExample('template-syntax/ts/app/app.module.1.ts', '', 'app.module.ts (FormsModule import)')
+  +makeExcerpt('app/app.module.1.ts (FormsModule import)', '')
 
 :marked
   ### Inside `[(ngModel)]`


### PR DESCRIPTION
Main fix is to file name (incorrectly) previously shown as `HeroDetailComponent.dart`.