### PR TITLE
docs(api): use git repo version of dartdoc, and setup frags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,23 @@ env:
 
 before_install:
   - source ./scripts/env-set.sh
+  - ./scripts/install-dart-sdk.sh
   - ./scripts/before-install.sh
   - rvm install 2.3.0
 
 install:
   - ./scripts/install.sh
-  - ./scripts/install-dart-sdk.sh
   - ./scripts/get-ng-repo.sh
-  - pub global activate linkcheck
-  # Use git repo version of dartdoc until most recent changes have made it into the SDK.
-  # Also see dartdoc command usage in gulp/dartdoc.js.
-  - pub global activate --source git https://github.com/dart-lang/dartdoc.git
 
 before_script:
-  - gulp create-example-fragments
-  - gulp dartdoc
+  - gulp dartdoc --dgeni-log=warn
 
 script:
   # - ./deploy/runtests.sh
   # - ./deploy/cibuild
-  - gulp build --dgeni-log=warn
+  # We use --fast to avoid setting up the fragments again;
+  # since it was done via `gulp dartdoc` above.
+  - gulp build --fast --dgeni-log=warn
 
 after_script:
   - ./scripts/check-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,12 @@ install:
   - ./scripts/install-dart-sdk.sh
   - ./scripts/get-ng-repo.sh
   - pub global activate linkcheck
+  # Use git repo version of dartdoc until most recent changes have made it into the SDK.
+  # Also see dartdoc command usage in gulp/dartdoc.js.
+  - pub global activate --source git https://github.com/dart-lang/dartdoc.git
 
 before_script:
+  - gulp create-example-fragments
   - gulp dartdoc
 
 script:

--- a/gulp/dartdoc.js
+++ b/gulp/dartdoc.js
@@ -32,7 +32,7 @@ module.exports = function(gulp, plugins, config) {
     // })
   });
 
-  gulp.task('_setup-fragments-for-dartdoc', () => {
+  gulp.task('_setup-fragments-for-dartdoc', ['create-example-fragments'], () => {
     const fragmentsDir = 'src/angular/_fragments';
     const ngRepoPath = config.angularRepo;
     const docsDir = path.resolve(ngRepoPath, 'docs');

--- a/gulp/dartdoc.js
+++ b/gulp/dartdoc.js
@@ -3,16 +3,22 @@
 module.exports = function(gulp, plugins, config) {
 
   const argv = plugins.argv;
+  const cp = plugins.child_process;
   const fs = plugins.fs;
   const path = plugins.path;
 
-  gulp.task('dartdoc', () => {
+  const dartdocCmd = 'pub global run dartdoc'
+
+  gulp.task('dartdoc', ['_setup-fragments-for-dartdoc'], () => {
     const ngRepoPath = config.angularRepo;
     if (argv.fast && fs.existsSync(path.resolve(ngRepoPath, config.relDartDocApiDir))) {
       plugins.gutil.log(`Skipping dartdoc: --fast flag enabled and api dir exists (${config.relDartDocApiDir})`);
       return true;
     }
-    return plugins.execp(`dartdoc --output ${config.relDartDocApiDir}`, { cwd: config.angularRepo });
+    return plugins.q.all(
+      plugins.execp(`${dartdocCmd} --version`),
+      plugins.execp(`${dartdocCmd} --output ${config.relDartDocApiDir}`, { cwd: config.angularRepo })
+    );
     // // checkAngularProjectPath(ngRepoPath);
     // const topLevelLibFilePath = path.resolve(ngRepoPath, 'lib', 'angular2.dart');
     // const tmpPath = topLevelLibFilePath + '.disabled';
@@ -24,6 +30,25 @@ module.exports = function(gulp, plugins, config) {
     //     gutil.log(`Restoring top-level angular2 library: ${topLevelLibFilePath}`);
     //     renameIfExistsSync(tmpPath, topLevelLibFilePath);
     // })
+  });
+
+  gulp.task('_setup-fragments-for-dartdoc', () => {
+    const fragmentsDir = 'src/angular/_fragments';
+    const ngRepoPath = config.angularRepo;
+    const docsDir = path.resolve(ngRepoPath, 'docs');
+
+    cp.execSync(`rm -Rf ${docsDir}`);
+    cp.execSync(`mkdir ${docsDir}`);
+
+    plugins.gutil.log(`Linking to fragment folders; cd ${docsDir}`);
+    const fragFolders = plugins.fs.readdirSync(fragmentsDir);
+    fragFolders.forEach(subdir => {
+      const fragSubdir = path.resolve(fragmentsDir, subdir, 'dart');
+      const cmd = `ln -s ${fragSubdir} ${subdir}`;
+      plugins.gutil.log(cmd);
+      cp.execSync(cmd, {cwd:docsDir});
+    });
+    return true;
   });
 
 };

--- a/scripts/before-install.sh
+++ b/scripts/before-install.sh
@@ -8,3 +8,13 @@ set -e -o pipefail
 travis_fold start before_install.npm_install
 (set -x; npm install -g firebase-tools gulp --no-optional)
 travis_fold end before_install.npm_install
+
+travis_fold start before_install.linkcheck
+(set -x; pub global activate linkcheck)
+travis_fold end before_install.linkcheck
+
+travis_fold start before_install.dartdoc
+echo "Use git repo version of dartdoc until most recent changes have made it into the SDK."
+echo "Also see dartdoc command usage in gulp/dartdoc.js."
+(set -x; pub global activate --source git https://github.com/dart-lang/dartdoc.git)
+travis_fold end before_install.dartdoc

--- a/scripts/config/linkcheck-skip-list.txt
+++ b/scripts/config/linkcheck-skip-list.txt
@@ -5,17 +5,14 @@
 # -----------------------
 
 # API search parameter links
-# Doesn't seem to work for now: /angular/api/#!\?apiFilter=
-/angular/api/.*apiFilter
+/angular/api/#!\?apiFilter=
 
 # Embedded SVG image data
-data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'
+# Doesn't seem to work for now: 
+^data
 
 # KNOWN ISSUES (to be investigated and/or resolved soon)
 # ------------
-
-# Just ignore all API links for now
-/angular/api/
 
 # Pages under development
 /angular/guide/router(\.html)?($|#)
@@ -24,8 +21,7 @@ data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'
 /angular/guide/change-log.html$
 /angular/cookbook/
 /angular/guide/appmodule.html$
-# Doesn't seem to work for now: /angular/guide/server-communication#.*(observable|promise|rxjs|search-parameters|server)
-/angular/guide/server-communication
+/angular/guide/server-communication#.*(observable|promise|rxjs|search-parameters|server)
 
 # Dartdoc related
 /angular/api/static-assets/fonts


### PR DESCRIPTION
- use git repo version of dartdoc until most recent changes make it into the next SDK release
- `gulp/dartdoc.js`: add step to setup access to doc sample fragments
- misc adjustments to `scripts/config/linkcheck-skip-list.txt` following recent fixes to the linkcheck tool

cc @filiph 