### PR TITLE
Add components to the sidenav

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -81,6 +81,13 @@
     - title: Glossary
       permalink: /angular/glossary
 
+- title: Angular Components
+  children:
+    - title: Code lab
+      permalink: /codelabs/angular2_components
+    - title: Example
+      permalink: https://dart-lang.github.io/angular2_components_example/
+
 - title: "Resources"
   children:
   - title: "Dart Tools for the Web"


### PR DESCRIPTION
Fixes #352 

Staged at: https://kw-webdev-dartlang-2.firebaseapp.com/angular

(Visible on any page except the homepage, as long as the window is wide enough.)