### PR TITLE
Follow-up on rename of GitHub repos for angular(2)_component(_example)

### DIFF
--- a/examples/ng/doc/template-syntax/lib/app_component.html
+++ b/examples/ng/doc/template-syntax/lib/app_component.html
@@ -658,7 +658,7 @@ bindon-ngModel
 <p>Pick your favorite hero</p>
 
 <material-radio-group [(ngModel)]="currentHero">
-  <!--  https://github.com/dart-lang/angular2_components/issues/61 - set checked "manually" -->
+  <!--  https://github.com/dart-lang/angular_components/issues/61 - set checked "manually" -->
   <material-radio *ngFor="let h of heroes" [value]="h" [checked]="h == currentHero">
     {{h.name}} ({{h.id}})
   </material-radio>

--- a/scripts/get-ng-repo.sh
+++ b/scripts/get-ng-repo.sh
@@ -23,7 +23,7 @@ else
   travis_fold start get_repos_acx
   echo GETTING Angular components repo from GitHub ...
   set -x
-  git clone https://github.com/dart-lang/angular2_components.git $ACX_REPO
+  git clone https://github.com/dart-lang/angular_components.git $ACX_REPO
   git -C $ACX_REPO fetch origin refs/tags/$ACX_RELEASE
   git -C $ACX_REPO checkout tags/$ACX_RELEASE -b $ACX_RELEASE
   set +x

--- a/src/_codelabs/angular2_components/1-base.md
+++ b/src/_codelabs/angular2_components/1-base.md
@@ -104,8 +104,8 @@ some of their vanilla HTML elements.
 
 ## <i class="fa fa-money"> </i> Get familiar with AngularDart Components
 
-Run the [AngularDart Components demo.](https://dart-lang.github.io/angular2_components_example/)
-Optionally, look at its [source code](https://github.com/dart-lang/angular2_components_example).
+Run the [AngularDart Components demo.](https://dart-lang.github.io/angular_components_example/)
+Optionally, look at its [source code](https://github.com/dart-lang/angular_components_example).
 
 <aside class="alert alert-info" markdown="1">
 **Note:**

--- a/src/_codelabs/angular2_components/what-next.md
+++ b/src/_codelabs/angular2_components/what-next.md
@@ -17,8 +17,8 @@ Here are some resources to help you use AngularDart Components.
 * [AngularDart documentation](/angular/guide)
 * AngularDart Components:
   * [API reference]({{site.acx_api}}/) for AngularDart Components
-  * Demo ([running](https://dart-lang.github.io/angular2_components_example/),
-    [source](https://github.com/dart-lang/angular2_components_example))
+  * Demo ([running](https://dart-lang.github.io/angular_components_example/),
+    [source](https://github.com/dart-lang/angular_components_example))
 
 <img src="/codelabs/angular2_components/images/cartoon.jpeg"
     alt="the cartoon that appears in the app's About tab" >

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -1,4 +1,4 @@
-- title: 
+- title:
   children:
   - title: Get Started
     permalink: /guides/get-started
@@ -91,7 +91,7 @@
     - title: Codelab
       permalink: /codelabs/angular2_components
     - title: Example
-      permalink: https://dart-lang.github.io/angular2_components_example/
+      permalink: https://dart-lang.github.io/angular_components_example/
     - title: API Reference
       permalink: /components/api
 


### PR DESCRIPTION
This is only for GitHub-specific URLs.
The rename of the package angular2_component will happen later

See https://github.com/orgs/dart-lang/projects/5