### PR TITLE
Clarify that web: OR --web-compiler is needed

### DIFF
--- a/src/tools/dartdevc.md
+++ b/src/tools/dartdevc.md
@@ -86,7 +86,7 @@ To make pub use dartdevc, do one of the following:
       debug: dartdevc
   ```
 
-* **Use the new `--web-compiler` flag** to `pub build` or `pub serve`.
+* Alternately, **use the new `--web-compiler` flag** to `pub build` or `pub serve`.
   Specify the `dartdevc` option:
 
   ```


### PR DESCRIPTION
I fear many people will miss the "do _one_ of the following" phrase and will end up doing both the change in pubspec and the command-line flag.