### PR TITLE
Upgrade to stream_transform v0.0.6

### DIFF
--- a/examples/ng/doc/toh-6/pubspec.yaml
+++ b/examples/ng/doc/toh-6/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   angular2: ^3.1.0
   http: ^0.11.0
-  stream_transform: ^0.0.5
+  stream_transform: ^0.0.6
   # #enddocregion additions
 dev_dependencies:
   angular_test: ^1.0.0-beta+2

--- a/examples/ng/doc/toh-6/test/hero_search.dart
+++ b/examples/ng/doc/toh-6/test/hero_search.dart
@@ -94,13 +94,9 @@ void heroSearchTests() {
 }
 
 Future _typeSearchTextAndRefreshPO(String searchText) async {
+  Future firstHero;
+  await fixture.update((c) => firstHero = c.heroes.first);
   await po.search.type(searchText);
-  // FIXME: Waiting on the stream doesn't work anymore:
-  // https://github.com/dart-lang/stream_transform/issues/18
-  //  Stream<List> heroesStream;
-  //  await fixture.update((c) => heroesStream = c.heroes);
-  //  await heroesStream.first;
-  // Until stream_transform/issues/18 is addressed, just wait a little:
-  await new Future.delayed(const Duration(seconds: 1));
+  await firstHero;
   po = await fixture.resolvePageObject(HeroSearchPO);
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/stream_transform/issues/18

This version has a fix for `debounce` to forward events to all
listeners.

Also updates the test to start listening for the first value on the
stream before typing through the page object since typing also waits for
the Timer to fire.