### PR TITLE
[WIP] Ensure links to API pkg entries are versioned

### DIFF
--- a/src/_plugins/api_url.rb
+++ b/src/_plugins/api_url.rb
@@ -1,0 +1,63 @@
+require 'cgi'
+
+module Jekyll
+  module Filters
+
+    # Usage:
+    #
+    #   api-entry-url | api_url: pub-package-name
+    #
+    # Example:
+    #
+    #   'formDirectives-constant' | api_url: 'angular_forms'
+    #
+    # Result:
+    #
+    #   https://pub.dartlang.org/documentation/angular_forms/2.0.0-alpha%2B3/angular_forms/formDirectives-constant.html
+    #
+    # Uses:
+    # 
+    #  - site.url
+    #  - site.data.pkg-vers
+
+    module ApiUrlFilter
+
+      PkgVersFile = 'pkg-vers'
+
+      def api_url(rawApiUri, pkgName)
+        apiUrlStart = trim_slashes(Jekyll.configuration({})['api'])
+        apiUri = rawApiUri.empty? ? "#{pkgName}-library" : trim_slashes(rawApiUri)
+        apiUri += '.html' unless apiUri =~ /\.html$/
+        apiUri.gsub!('+', '%2B')
+
+        # Attempt to get the current version of the named package
+        site = @context.registers[:site]
+        data = site.data[PkgVersFile][pkgName]
+        raise ArgumentError, notFound('data', pkgName) unless data
+        pkgVers = data['vers']
+        raise ArgumentError, notFound('version', pkgName) unless pkgVers
+
+        [apiUrlStart,
+         pkgName,
+         CGI.escape(pkgVers),
+         pkgName,
+         apiUri,
+        ].join('/')
+      end
+
+      def trim_slashes(s)
+        s[0] = '' if s.start_with? '/'
+        s.chomp('/')
+      end
+
+      private
+
+      def notFound(what, pkgName)
+        "Package #{what} not found for '#{pkgName}' in #{PkgVersFile}"
+      end
+
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::Filters::ApiUrlFilter)

--- a/src/angular/tutorial/toh-pt1.md
+++ b/src/angular/tutorial/toh-pt1.md
@@ -267,7 +267,7 @@ In the [next tutorial page](toh-pt2), you'll build on the Tour of Heroes app to 
 You'll also allow the user to select heroes and display their details.
 You'll learn more about how to retrieve lists and bind them to the template.
 
-[angular_forms]: /api/angular_forms
+[angular_forms]: {{ '' | api_url: 'angular_forms' }}
 [build_runner serve]: /tools/build_runner#serve
-[formDirectives]: /api/angular_forms/angular_forms/formDirectives-constant
+[formDirectives]: {{ 'formDirectives-constant' | api_url: 'angular_forms' }}
 [interpolation syntax]: /angular/guide/template-syntax#interpolation


### PR DESCRIPTION
Contributes to #1440

This PR introduces a Jekyll filter to help create links to package API entries. For example, what used to be:

```markdown
[angular_forms]: /api/angular_forms
[formDirectives]: /api/angular_forms/angular_forms/formDirectives-constant
```

will now be written as

```markdown
[angular_forms]: {{ '' | api_url: 'angular_forms' }}
[formDirectives]: {{ 'formDirectives-constant' | api_url: 'angular_forms' }}
```

In the rendered HTML the links are, respectively:

- https://pub.dartlang.org/documentation/angular_forms/2.0.0-alpha%2B3/angular_forms/angular_forms-library.html
- https://pub.dartlang.org/documentation/angular_forms/2.0.0-alpha%2B3/angular_forms/formDirectives-constant.html