### PR TITLE
"AdWords" --> "Google Ads"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,7 @@ description: Dart is a modern language well suited to writing fast, scalable, we
         <div class="content">
           <p>Google builds many critical web apps using the
             <a href="{{site.dartlang}}" class="no-automatic-external">Dart programming language</a>, often with
-            <a href="/angular">AngularDart</a>. The next generation of Google AdWords is built in Dart. Google Fiber&rsquo;s latest web app
+            <a href="/angular">AngularDart</a>. The Google Ads front end is built in Dart. Google Fiber&rsquo;s latest web app
             is built in it. So is Google&rsquo;s internal CRM.</p>
           <p>Outside Google, amazing companies like Wrike, Blossom, Workiva, and DGLogik have been building their products in
             Dart.


### PR DESCRIPTION
Remove reference to "AdWords" in favor of "Google Ads." Also removed "next generation" since it's the only one now.

Details: https://www.blog.google/technology/ads/new-advertising-brands/