### PR TITLE
Fix import bug in Tour of Heroes tutorial pt6

### DIFF
--- a/src/angular/tutorial/toh-pt6.md
+++ b/src/angular/tutorial/toh-pt6.md
@@ -87,7 +87,7 @@ so provide it through the app's root injector:
 ```
   import 'package:angular/angular.dart';
   import 'package:angular_router/angular_router.dart';
-  import 'package:angular_tour_of_heroes/app_component.template.dart' as ng;
+  import 'package:angular_app/app_component.template.dart' as ng;
   import 'package:http/browser_client.dart';
 
   import 'main.template.dart' as self;
@@ -124,8 +124,8 @@ Update `web/main.dart` with this version, which uses the mock service:
 ```
   import 'package:angular/angular.dart';
   import 'package:angular_router/angular_router.dart';
-  import 'package:angular_tour_of_heroes/app_component.template.dart' as ng;
-  import 'package:angular_tour_of_heroes/in_memory_data_service.dart';
+  import 'package:angular_app/app_component.template.dart' as ng;
+  import 'package:angular_app/in_memory_data_service.dart';
   import 'package:http/http.dart';
 
   import 'main.template.dart' as self;


### PR DESCRIPTION
Part 6 of of the ToH tutorial creates a lib/-level
service and imports it using the name
'angular_tour_of_heroes' in the path where the current
version (running webdev 1.0.0) seems to require
'angular_app' instead.