### PR TITLE
Redirect old Angular API pages to new equivalents.

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,7 +9,7 @@
       { "source": "/angular@(|.html)", "destination": "https://angulardart.dev/", "type": 301 },
       { "source": "/angular/api@(|.html)", "destination": "https://angulardart.dev/api?package=angular", "type": 301 },
       { "source": "/angular/api/**", "destination": "https://angulardart.dev/api?package=angular", "type": 301 },
-      { "source": "/api/angular/angular@(|.html)", "destination": "https://angulardart.dev/api/angular/angular/angular-library", "type": 301 },
+      { "source": "/api/angular/:topic*", "destination": "https://angulardart.dev/api/angular/:topic", "type": 301 },
       { "source": "/api/angular_components/angular_components@(|.html)", "destination": "https://angulardart.dev/api/angular_components/angular_components/angular_components-library", "type": 301 },
       { "source": "/api/angular2@(|.html)", "destination": "https://angulardart.dev/api?package=angular", "type": 301 },
       { "source": "/api/angular2/**", "destination": "https://angulardart.dev/api", "type": 301 },


### PR DESCRIPTION
Use a [capture segment][1] to point redirects from old documentation
URLs to the same page on the new site.

[1]: https://firebase.google.com/docs/hosting/full-config#capture_url_segments_for_redirects